### PR TITLE
Decode hash to string, not byte sequence

### DIFF
--- a/shopify_webhook/helpers.py
+++ b/shopify_webhook/helpers.py
@@ -24,7 +24,7 @@ def get_hmac(body, secret):
     See: http://docs.shopify.com/api/tutorials/using-webhooks#verify-webhook
     """
     hash = hmac.new(secret.encode('utf-8'), body, hashlib.sha256)
-    return base64.b64encode(hash.digest())
+    return base64.b64encode(hash.digest()).decode()
 
 
 def hmac_is_valid(body, secret, hmac_to_verify):

--- a/shopify_webhook/tests/__init__.py
+++ b/shopify_webhook/tests/__init__.py
@@ -42,7 +42,7 @@ class WebhookTestCase(TestCase):
         if topic:
             headers['HTTP_X_SHOPIFY_TOPIC'] = topic
         if send_hmac:
-            headers['HTTP_X_SHOPIFY_HMAC_SHA256'] = get_hmac(six.b(data), settings.SHOPIFY_APP_API_SECRET)
+            headers['HTTP_X_SHOPIFY_HMAC_SHA256'] = six.text_type(get_hmac(six.b(data), settings.SHOPIFY_APP_API_SECRET))
 
         return self.client.post(self.webhook_url, data = data, content_type = 'application/json', **headers)
 


### PR DESCRIPTION
Not decoding caused comparison to fail on Python 3.6