### PR TITLE
Made it possible to overwrite how secret token is passed

### DIFF
--- a/shopify_webhook/helpers.py
+++ b/shopify_webhook/helpers.py
@@ -77,3 +77,8 @@ def proxy_signature_is_valid(request, secret):
         return hmac.compare_digest(calculated_signature.encode('utf-8'), signature_to_verify.encode('utf-8'))
     except AttributeError:
         return calculated_signature == signature_to_verify
+
+
+def get_secret(request, *args, **kwargs):
+    return settings.SHOPIFY_APP_API_SECRET
+

--- a/shopify_webhook/tests/__init__.py
+++ b/shopify_webhook/tests/__init__.py
@@ -20,6 +20,7 @@ class WebhookTestCase(TestCase):
         """
         super(WebhookTestCase, self).setUp()
         self.webhook_url = reverse('webhook')
+        self.api_secret = settings.SHOPIFY_APP_API_SECRET
 
     def post_shopify_webhook(self, topic = None, domain = None, data = None, headers = None, send_hmac = True):
         """
@@ -41,7 +42,7 @@ class WebhookTestCase(TestCase):
         if topic:
             headers['HTTP_X_SHOPIFY_TOPIC'] = topic
         if send_hmac:
-            headers['HTTP_X_SHOPIFY_HMAC_SHA256'] = str(get_hmac(data.encode("latin-1"), settings.SHOPIFY_APP_API_SECRET))
+            headers['HTTP_X_SHOPIFY_HMAC_SHA256'] = str(get_hmac(data.encode("latin-1"), self.api_secret))
 
         return self.client.post(self.webhook_url, data = data, content_type = 'application/json', **headers)
 


### PR DESCRIPTION
The goal of this change is to make it possible to pass the secret token in another way than via settings. This can be useful eg in case that there are multiple Shopify apps sharing the same codebase. 

The change should be fully backward compatible.


Example of usage:

```
def get_secret(request, *args, **kwargs):
    # logic to get secret
    secret = 'xx'
    return secret


@webhook(get_secret_func=get_secret)
def webhook_receiver(request):
    # process webhook
    return HttpResponse("OK")
```
