### PR TITLE
Signals: remove deprecated provided_args argument

### DIFF
--- a/shopify_webhook/signals.py
+++ b/shopify_webhook/signals.py
@@ -4,11 +4,12 @@ from django.dispatch import Signal
 class WebhookSignal(Signal):
     """
     A class wrapping Signal with the common arguments for Webhooks.
+    Common arguments:
+        * domain
+        * topic
+        * data
     """
-
-    def __init__(self):
-        providing_args = ['domain', 'topic', 'data']
-        super(WebhookSignal, self).__init__(providing_args = providing_args)
+    pass
 
 
 # Define a generic webhook_received signal that triggers for all webhooks.


### PR DESCRIPTION
replaced by docstring as Django advises